### PR TITLE
Actually close the server, sthread, and client when `Bye.` is sent by the client.

### DIFF
--- a/SThread.java
+++ b/SThread.java
@@ -48,12 +48,16 @@ public class SThread extends Thread {
 			// Communication loop
 			while ((inputLine = in.readLine()) != null) {
 				System.out.println("Client/Server said: " + inputLine);
-				if (inputLine.equals("Bye.")) // exit statement
-					break;
 				outputLine = inputLine; // passes the input from the machine to the output string for the destination
 
 				if (outSocket != null) {
 					outTo.println(outputLine); // writes to the destination
+				}
+
+				// exit statement
+				if (inputLine.equals("BYE.")) {
+					System.out.println("Sever Thread: terminating...");
+					break;
 				}
 			} // end while
 		} // end try

--- a/TCPClient.java
+++ b/TCPClient.java
@@ -50,8 +50,13 @@ public class TCPClient {
         while ((fromServer = in.readLine()) != null) {
             System.out.println("Server: " + fromServer);
             t1 = System.currentTimeMillis();
-            if (fromServer.equals("Bye.")) // exit statement
+
+            // exit statement
+            if (fromServer.equals("BYE.")) {
+                System.out.println("Client: terminating...");
                 break;
+            }
+
             t = t1 - t0;
             System.out.println("Cycle time: " + t);
 

--- a/TCPServer.java
+++ b/TCPServer.java
@@ -41,11 +41,15 @@ public class TCPServer {
         // Communication while loop
         while ((fromClient = in.readLine()) != null) {
             System.out.println("Client said: " + fromClient);
-            if (fromClient.equals("Bye.")) // exit statement
-                break;
             fromServer = fromClient.toUpperCase(); // converting received message to upper case
             System.out.println("Server said: " + fromServer);
             out.println(fromServer); // sending the converted message back to the Client via ServerRouter
+
+            // exit statement
+            if (fromClient.equals("Bye.")) {
+                System.out.println("Server: terminating...");
+                break;
+            }
         }
 
         // closing connections

--- a/file.txt
+++ b/file.txt
@@ -5,3 +5,4 @@ This iS a LonG LiNe of Text
 Lion
 test all lower case
 TEST ALL UPPER CASE
+Bye.


### PR DESCRIPTION
Prior to this commit, when the client sent `Bye.`, the SThread would close immediately before passing the message to the server. This prevented the server from sending `BYE.` (the client was expecting `Bye.` so this wouldn't have worked anyway) back to confirm to the client that it closed and that the client is free to close as well.

The server router will still continue running after this change to handle more incoming connections.